### PR TITLE
MSVC Unicode compile error fixes

### DIFF
--- a/FCollada/FUtils/FUTestBed.cpp
+++ b/FCollada/FUtils/FUTestBed.cpp
@@ -46,7 +46,8 @@ bool FUTestBed::RunTestbed(FUTestSuite* headTestSuite)
 		returnCode = MessageBox(NULL, TO_FSTRING(sz).c_str(), FC("Testbed"), MB_OKCANCEL);
 		if (returnCode == IDCANCEL)
 		{
-			snprintf(sz, 1024, "write %s ", filename.c_str());
+			const fm::string filenameUtf8 = FUStringConversion::ToString(filename);
+			snprintf(sz, 1024, "write %s ", filenameUtf8.c_str());
 			sz[1023] = 0;
 			system(sz);
 			return false;

--- a/FColladaPlugins/FArchiveXML/FAXAnimationImport.cpp
+++ b/FColladaPlugins/FArchiveXML/FAXAnimationImport.cpp
@@ -469,7 +469,7 @@ bool FArchiveXML::LoadAnimationClip(FCDObject* object, xmlNode* clipNode)
 		animationClip->SetAnimationName(name, animationClip->GetAnimationCount() - 1);
 
 		FUUri animationId = ReadNodeUrl(*itI);
-		FCDAnimation* animation = animationClip->GetDocument()->FindAnimation(animationId.GetFragment());
+		FCDAnimation* animation = animationClip->GetDocument()->FindAnimation(FUStringConversion::ToString(animationId.GetFragment()));
 		if (animation == NULL) continue;
 
 		// Retrieve all the curves created under this animation node


### PR DESCRIPTION
Fixed a couple of type errors that showed up when I enabled Unicode build in MSVC (mostly fm::string-fm::fstring mixups)

If you accept my other warning fixes pull request first, git might complain about a merge conflict. But at least TortoiseGit was able to merge the changes automatically anyways.
