### PR TITLE
CMakeLists.txt refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,43 @@
+cmake_minimum_required(VERSION 2.6)
+
+project(FCollada)
+
 SET(TARGET "OMKFCollada")
 
-# "DLL" is not only used on Win32 platforms!
-ADD_DEFINITIONS("-DFCOLLADA_DLL")
-# I'm beggining to take drugs...
-ADD_DEFINITIONS("-DFCOLLADA_INTERNAL")
-# If you need to link statically libxml2 with OMKFCollada, uncomment the
-# following line
-# (if you try to use it with a dynamic linking, you may experience problems
-# with the _xmlfree symbol not resolved)
-#ADD_DEFINITIONS("-DLIBXML_STATIC_LINKING")
+option(BUILD_SHARED_LIBS "build a shared library" OFF)
+if(BUILD_SHARED_LIBS)
+	# "DLL" is not only used on Win32 platforms!
+	ADD_DEFINITIONS(-DFCOLLADA_DLL)
+endif(BUILD_SHARED_LIBS)
+
+# Let the sources know, that we're building FCollada now
+ADD_DEFINITIONS(-DFCOLLADA_INTERNAL)
+
+# Backwards compatibility with the old non-standard parameters
+if(DEFINED LIBXML2_INC)
+	set(LIBXML2_INCLUDE_DIR ${LIBXML2_INC})
+endif(DEFINED LIBXML2_INC)
+
+if(DEFINED LIBXML2_LIBS AND DEFINED LIBXML2_LIBDIR)
+	foreach(libName ${LIBXML2_LIBS})
+		find_library(libxml2_${libName} NAMES ${libName} PATHS ${LIBXML2_LIBDIR})
+		if(libxml2_${libName})
+			list(APPEND LIBXML2_LIBRARIES ${libxml2_${libName}})
+		endif(libxml2_${libName})
+	endforeach(libName ${LIBXML2_LIBS})
+endif(DEFINED LIBXML2_LIBS AND DEFINED LIBXML2_LIBDIR)
+
+find_package(LibXml2 REQUIRED)
+
+option(LIBXML_STATIC_LINKING "link libxml2 statically" OFF)
+if(LIBXML_STATIC_LINKING)
+	# (if you try to use it with a dynamic linking, you may experience problems
+	# with the _xmlfree symbol not resolved)
+	list(APPEND LIBXML2_DEFINITIONS LIBXML_STATIC_LINKING)
+endif(LIBXML_STATIC_LINKING)
+
+mark_as_advanced(LIBXML_STATIC_LINKING)
+
 
 IF(UNIX)
   IF(CMAKE_COMPILER_IS_GNUCXX)
@@ -21,35 +50,16 @@ IF(UNIX)
         MESSAGE(FATAL_ERROR "g++ cannot be found!")
     ENDIF(GNUCXX_UNFOUND)
 
-    # We want to be compatible with CMake 2.4 but previous to version 2.6,
-    # CMake does not support VERSION_LESS. So, Cmake version checking is
-    # required and STRLESS will be used. STRLESS can miscompare strings with
-    # versions!
-    IF(${CMAKE_MAJOR_VERSION} STREQUAL "2" AND ${CMAKE_MINOR_VERSION} STRGREATER "4")
-        IF(${GNUCXX_VERSION} VERSION_LESS "4.3")
-            # With older versions of g++, flag "-fno-inline-functions" have to be used
-            SET(CMAKE_CXX_FLAGS_RELEASE "-fno-inline-functions ${CMAKE_CXX_FLAGS_RELEASE}")
-        ELSEIF(${GNUCXX_VERSION} VERSION_LESS "4.4")
-            # With g++ at version 4.3, flag "-fno-inline-small-functions" have to be used
-            SET(CMAKE_CXX_FLAGS_RELEASE "-fno-inline-small-functions ${CMAKE_CXX_FLAGS_RELEASE}")
-        ELSEIF(${GNUCXX_VERSION} VERSION_EQUAL "4.4" OR ${GNUCXX_VERSION} VERSION_GREATER "4.4")
-            #With g++ at version 4.4, there is probably a flag more relevant... but let us use -O1
-            SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O1")
-        ENDIF(${GNUCXX_VERSION} VERSION_LESS "4.3")
-    ELSE(${CMAKE_MAJOR_VERSION} STREQUAL "2" AND ${CMAKE_MINOR_VERSION} STRGREATER "4")
-        IF(${GNUCXX_VERSION} STRLESS "4.3")
-            # With older versions of g++, flag "-fno-inline-functions" have to be used
-            SET(CMAKE_CXX_FLAGS_RELEASE "-fno-inline-functions ${CMAKE_CXX_FLAGS_RELEASE}")
-        ELSEIF(${GNUCXX_VERSION} STREQUAL "4.3" OR ${GNUCXX_VERSION} STRGREATER "4.3")
-            IF (${GNUCXX_VERSION} STRLESS "4.4")
-                # With g++ at version 4.3, flag "-fno-inline-small-functions" have to be used
-                SET(CMAKE_CXX_FLAGS_RELEASE "-fno-inline-small-functions ${CMAKE_CXX_FLAGS_RELEASE}")
-            ELSE(${GNUCXX_VERSION} STRLESS "4.4")
-                #With g++ at version 4.4, there is probably a flag more relevant... but let us use -O1
-                SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O1")
-            ENDIF(${GNUCXX_VERSION} STRLESS "4.4")
-        ENDIF(${GNUCXX_VERSION} STRLESS "4.3")
-    ENDIF(${CMAKE_MAJOR_VERSION} STREQUAL "2" AND ${CMAKE_MINOR_VERSION} STRGREATER "4")
+    IF(${GNUCXX_VERSION} VERSION_LESS "4.3")
+        # With older versions of g++, flag "-fno-inline-functions" have to be used
+        SET(CMAKE_CXX_FLAGS_RELEASE "-fno-inline-functions ${CMAKE_CXX_FLAGS_RELEASE}")
+    ELSEIF(${GNUCXX_VERSION} VERSION_LESS "4.4")
+        # With g++ at version 4.3, flag "-fno-inline-small-functions" have to be used
+        SET(CMAKE_CXX_FLAGS_RELEASE "-fno-inline-small-functions ${CMAKE_CXX_FLAGS_RELEASE}")
+    ELSEIF(${GNUCXX_VERSION} VERSION_EQUAL "4.4" OR ${GNUCXX_VERSION} VERSION_GREATER "4.4")
+        #With g++ at version 4.4, there is probably a flag more relevant... but let us use -O1
+        SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O1")
+    ENDIF(${GNUCXX_VERSION} VERSION_LESS "4.3")
 
   ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 ENDIF(UNIX)
@@ -61,6 +71,7 @@ SET(MODULE_FOLDERS
   ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FMath
   ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FUtils
 )
+
 # Get the header files
 FOREACH(folder ${MODULE_FOLDERS})
   FILE(GLOB tmpHFILES
@@ -80,11 +91,8 @@ FOREACH(folder ${MODULE_FOLDERS})
 ENDFOREACH(folder)
 SET(CPPFILES ${H_FILES} ${CPPFILES})
 
-MESSAGE(STATUS ">>>>>> Project: ${PROJECT_NAME}")
-MESSAGE(STATUS ">>> Files: ${CPPFILES}")
-
 INCLUDE_DIRECTORIES(
-  ${LIBXML2_INC}
+  ${LIBXML2_INCLUDE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/FCollada
   ${CMAKE_CURRENT_SOURCE_DIR}/FColladaPlugins
   ${CMAKE_CURRENT_SOURCE_DIR}/FColladaPlugins/FArchiveXML
@@ -93,73 +101,36 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FUtils
 )
 
-IF(_WIN32)
-    SOURCE_GROUP( FColladaPlugins REGULAR_EXPRESSION ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FColladaPlugins/FArchiveXML/* )
-    SOURCE_GROUP( FCDocument      REGULAR_EXPRESSION ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FCollada/FCDocument/* )
-    SOURCE_GROUP( FMath           REGULAR_EXPRESSION ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FCollada/FMath/* )
-    SOURCE_GROUP( FUtils          REGULAR_EXPRESSION ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FCollada/FUtils/* )
+SOURCE_GROUP(FColladaPlugins REGULAR_EXPRESSION ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FColladaPlugins/FArchiveXML/* )
+SOURCE_GROUP(FCDocument      REGULAR_EXPRESSION ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FCollada/FCDocument/* )
+SOURCE_GROUP(FMath           REGULAR_EXPRESSION ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FCollada/FMath/* )
+SOURCE_GROUP(FUtils          REGULAR_EXPRESSION ${CMAKE_CURRENT_SOURCE_DIR}/FCollada/FCollada/FUtils/* )
 
-    # not needed on Unix because we find libraries ourselves
-    LINK_DIRECTORIES(
-      ${LIBXML2_LIBDIR}
-    )
-ENDIF(_WIN32)
-
-ADD_LIBRARY(${TARGET} SHARED ${CPPFILES})
+ADD_LIBRARY(${TARGET} ${CPPFILES})
 
 #link with external libs
-IF(_WIN32)
-  TARGET_LINK_LIBRARIES(${TARGET} ${LIBXML2_LIBS})
+TARGET_LINK_LIBRARIES(${TARGET} ${LIBXML2_LIBRARIES})
 
+IF(WIN32 AND NOT DEFINED CMAKE_DEBUG_POSTFIX)
   IF(MSVC71)
-    SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "_vc71_d" RELEASE_POSTFIX "_vc71")
+    SET_TARGET_PROPERTIES(${TARGET} PROPERTIES DEBUG_POSTFIX "_vc71_d" RELEASE_POSTFIX "_vc71")
   ELSEIF(MSVC80)
-    SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "_vc80_d" RELEASE_POSTFIX "_vc80")
+    SET_TARGET_PROPERTIES(${TARGET} PROPERTIES DEBUG_POSTFIX "_vc80_d" RELEASE_POSTFIX "_vc80")
   ELSEIF(MSVC90)
-    SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "_vc90_d" RELEASE_POSTFIX "_vc90")
+    SET_TARGET_PROPERTIES(${TARGET} PROPERTIES DEBUG_POSTFIX "_vc90_d" RELEASE_POSTFIX "_vc90")
   ELSE(MSVC71)
-    SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "_d")
+    SET_TARGET_PROPERTIES(${TARGET} PROPERTIES DEBUG_POSTFIX "_d")
   ENDIF(MSVC71)
-ELSE(_WIN32)
-  MACRO(FIND_AND_LINK_LIBRARIES LIB_TARGET LIBS LIBDIR)
-    FOREACH(lib ${LIBS})
-      # try to find the library only in the paths provided
-      FIND_LIBRARY(var${lib}
-        NAMES ${lib}
-        PATHS ${LIBDIR}
-        NO_DEFAULT_PATH )
-      IF(EXISTS ${var${lib}})
-        TARGET_LINK_LIBRARIES(${LIB_TARGET} ${var${lib}})
-      ELSE(EXISTS ${var${lib}})
-        # try one more time but with a wider scope to find the library
-        FIND_LIBRARY(var${lib}
-          NAMES ${lib}
-          PATHS ${LIBDIR} )
-        IF(EXISTS ${var${lib}})
-          TARGET_LINK_LIBRARIES(${LIB_TARGET} ${var${lib}})
-        ELSE(EXISTS ${var${lib}})
-          MESSAGE(FATAL_ERROR "ERROR: could not find ${lib} on path: ${LIBDIR}")
-        ENDIF(EXISTS ${var${lib}})
-      ENDIF(EXISTS ${var${lib}})
-    ENDFOREACH(lib)
-  ENDMACRO(FIND_AND_LINK_LIBRARIES LIB_TARGET LIBS LIBDIR)
+ENDIF(WIN32 AND NOT DEFINED CMAKE_DEBUG_POSTFIX)
 
-  # libxml2
-  FIND_AND_LINK_LIBRARIES("${TARGET}" "${LIBXML2_LIBS}" "${LIBXML2_LIBDIR}")
-ENDIF(_WIN32)
+# Avoid transitive linking of dynamic libraries.
+# If B depends on A, C on B, then C will only depend on B (not A).
+# This setting doesn't have any effect on static libraries
+SET_TARGET_PROPERTIES(${TARGET} PROPERTIES LINK_INTERFACE_LIBRARIES "")
 
-# the following code is only supported by CMake versions above 2.4
-IF(${CMAKE_MAJOR_VERSION} STREQUAL "2" AND ${CMAKE_MINOR_VERSION} STRGREATER "4")
-  # Avoid transitive linking of dynamic libraries.
-  # If B depends on A, C on B, then C will only depend on B (not A).
-  # This setting doesn't have any effect on static libraries
-  SET_TARGET_PROPERTIES(${MODULE_NAME}
-      PROPERTIES
-      LINK_INTERFACE_LIBRARIES ""
-  )
-ENDIF(${CMAKE_MAJOR_VERSION} STREQUAL "2" AND ${CMAKE_MINOR_VERSION} STRGREATER "4")
-
-SET_TARGET_PROPERTIES(${TARGET} PROPERTIES VERSION ${PROJECT_VERSION_FULL})
+if(DEFINED PROJECT_VERSION_FULL)
+	SET_TARGET_PROPERTIES(${TARGET} PROPERTIES VERSION ${PROJECT_VERSION_FULL})
+endif(DEFINED PROJECT_VERSION_FULL)
 
 FILE(GLOB H_ROOT_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} FCollada/*.h FCollada/*.hpp)
 FILE(GLOB H_FARCHIVEXML_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} FColladaPlugins/FArchiveXML/*.h FColladaPlugins/FArchiveXML/*.hpp)
@@ -167,46 +138,29 @@ FILE(GLOB H_FCDOCUMENT_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} FCollada/FCDoc
 FILE(GLOB H_FMATH_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} FCollada/FMath/*.h FCollada/FCDocument/*.hpp)
 FILE(GLOB H_FUTILS_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} FCollada/FUtils/*.h FCollada/FUtils/*.hpp)
 
-IF(UNIX)
-  #install headers
+IF(UNIX AND DEFINED INSTALLPREFIX)
   SET(OMKFCOLLADA_INC_DIR ${INSTALLPREFIX}/include/OMKFCollada)
-  #for root headers
-  FOREACH(file ${H_ROOT_FILES} )
-    INSTALL(FILES ${file} DESTINATION ${OMKFCOLLADA_INC_DIR})
-  ENDFOREACH(file)
-  #for FArchiveXML
-  FOREACH(file ${H_FARCHIVEXML_FILES} )
-    INSTALL(FILES ${file} DESTINATION ${OMKFCOLLADA_INC_DIR}/FArchiveXML/)
-  ENDFOREACH(file)
-  #for FCDocument
-  FOREACH(file ${H_FCDOCUMENT_FILES} )
-    INSTALL(FILES ${file} DESTINATION ${OMKFCOLLADA_INC_DIR}/FCDocument/)
-  ENDFOREACH(file)
-  #for FMath
-  FOREACH(file ${H_FMATH_FILES} )
-    INSTALL(FILES ${file} DESTINATION ${OMKFCOLLADA_INC_DIR}/FMath/)
-  ENDFOREACH(file)
-  #for FUtils
-  FOREACH(file ${H_FUTILS_FILES} )
-    INSTALL(FILES ${file} DESTINATION ${OMKFCOLLADA_INC_DIR}/FUtils/)
-  ENDFOREACH(file)
-
-  #install lib
-  INSTALL(TARGETS ${TARGET} LIBRARY DESTINATION ${INSTALLPREFIX}/lib/)
-
-ELSE(UNIX)
-  #install headers
+	set(OMKFCOLLADA_LIB_DIR ${INSTALLPREFIX}/lib)
+	set(OMKFCOLLADA_BIN_DIR ${INSTALLPREFIX}/bin)
+ELSE(UNIX AND DEFINED INSTALLPREFIX)
   SET(OMKFCOLLADA_INC_DIR include/OMKFCollada)
-  INSTALL(FILES ${H_ROOT_FILES} DESTINATION ${OMKFCOLLADA_INC_DIR})
-  INSTALL(FILES ${H_FARCHIVEXML_FILES} DESTINATION ${OMKFCOLLADA_INC_DIR}/FArchiveXML)
-  INSTALL(FILES ${H_FCDOCUMENT_FILES} DESTINATION ${OMKFCOLLADA_INC_DIR}/FCDocument)
-  INSTALL(FILES ${H_FMATH_FILES} DESTINATION ${OMKFCOLLADA_INC_DIR}/FMath)
-  INSTALL(FILES ${H_FUTILS_FILES} DESTINATION ${OMKFCOLLADA_INC_DIR}/FUtils)
-    
-  #install lib
-  INSTALL(TARGETS ${TARGET} DESTINATION lib)
+	set(OMKFCOLLADA_LIB_DIR lib)
+	set(OMKFCOLLADA_BIN_DIR bin)
+ENDIF(UNIX AND DEFINED INSTALLPREFIX)
 
-ENDIF(UNIX)
+#install headers
+INSTALL(FILES ${H_ROOT_FILES} DESTINATION ${OMKFCOLLADA_INC_DIR})
+INSTALL(FILES ${H_FARCHIVEXML_FILES} DESTINATION ${OMKFCOLLADA_INC_DIR}/FArchiveXML)
+INSTALL(FILES ${H_FCDOCUMENT_FILES} DESTINATION ${OMKFCOLLADA_INC_DIR}/FCDocument)
+INSTALL(FILES ${H_FMATH_FILES} DESTINATION ${OMKFCOLLADA_INC_DIR}/FMath)
+INSTALL(FILES ${H_FUTILS_FILES} DESTINATION ${OMKFCOLLADA_INC_DIR}/FUtils)
+    
+#install lib
+INSTALL(TARGETS ${TARGET}
+	ARCHIVE DESTINATION ${OMKFCOLLADA_LIB_DIR}
+	LIBRARY DESTINATION ${OMKFCOLLADA_LIB_DIR}
+	RUNTIME DESTINATION ${OMKFCOLLADA_BIN_DIR}
+)
 
 #generate OMKFcollada.pc which will move at install
 IF(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ endif(BUILD_SHARED_LIBS)
 # Let the sources know, that we're building FCollada now
 ADD_DEFINITIONS(-DFCOLLADA_INTERNAL)
 
+if(MSVC)
+	add_definitions(-DUNICODE -D_UNICODE)
+endif(MSVC)
+
 # Backwards compatibility with the old non-standard parameters
 if(DEFINED LIBXML2_INC)
 	set(LIBXML2_INCLUDE_DIR ${LIBXML2_INC})


### PR DESCRIPTION
Refactored CMakeLists.txt to be a little more consistent and removed compatibility hacks for ancient CMake versions.

Then simplified it where appropriate and moved over to using find_package(LibXml2 REQUIRED) instead of that custom library discovery while maintaining compatibility to the previous configuration variables.

Eventually MSVC and Unicode support were added aswell as the possibility to compile a static instead of a shared library.
